### PR TITLE
add a post-install message

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <img src="https://developer.nexmo.com/assets/images/Vonage_Nexmo.svg" height="48px" alt="Nexmo is now known as Vonage" />
 
-|<p align="left">:exclamation: This SDK and Ruby gem have moved! It is now [`vonage`](https://rubygems.org/gems/vonage), located at [vonage/vonage-ruby-sdk](https://github.com/vonage/vonage-ruby-sdk). <br /><br /> We will support this repository for 12 months, ending October 2021, with any needed bug or security fixes for the last release of v7.2.0. New features will be released under `vonage`, so to take advantage of those please make sure to switch to `vonage` as soon as possible so you don't miss out!</p>   |
+|<p align="left">:exclamation: This SDK and Ruby gem have moved! It is now [`vonage`](https://rubygems.org/gems/vonage), located at [vonage/vonage-ruby-sdk](https://github.com/vonage/vonage-ruby-sdk). <br /><br /> We will support this repository for 12 months, ending October 2021, with any needed bug or security fixes for the last release of v7.2.1. New features will be released under `vonage`, so to take advantage of those please make sure to switch to `vonage` as soon as possible so you don't miss out!</p>   |
 |-----------------------------------------|
 
 This is the Ruby client library for Nexmo's API. To use it you'll

--- a/lib/nexmo/version.rb
+++ b/lib/nexmo/version.rb
@@ -1,5 +1,5 @@
 # typed: strong
 
 module Nexmo
-  VERSION = '7.2.0'
+  VERSION = '7.2.1'
 end

--- a/nexmo.gemspec
+++ b/nexmo.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.post_install_message = <<~HEREDOC
     This Ruby gem has moved to `vonage`!
 
-    We will support this last release of `nemo` through October 2021 with any needed bug fixes or security fixes.
+    We will support this last release of `nexmo` through October 2021 with any needed bug fixes or security fixes.
 
     New features will only be relased under the new `vonage` gem, so make sure to switch as soon as you can.
 

--- a/nexmo.gemspec
+++ b/nexmo.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |s|
     This Ruby gem has moved to `vonage`!
 
     We will support this last release of `nemo` through October 2021 with any needed bug fixes or security fixes.
-  
+
     New features will only be relased under the new `vonage` gem, so make sure to switch as soon as you can.
 
     To switch now, change your dependency in your `Gemfile` to `vonage` or run `gem install vonage` from the command line.
-    
+
     You can find more information on GitHub at https://github.com/Vonage/vonage-ruby-sdk.
   HEREDOC
   s.metadata = {

--- a/nexmo.gemspec
+++ b/nexmo.gemspec
@@ -17,6 +17,17 @@ Gem::Specification.new do |s|
   s.add_dependency('sorbet-runtime', '~> 0.5')
   s.add_development_dependency('timecop', '~> 0.9')
   s.require_path = 'lib'
+  s.post_install_message = <<~HEREDOC
+    This Ruby gem has moved to `vonage`!
+
+    We will support this last release of `nemo` through October 2021 with any needed bug fixes or security fixes.
+  
+    New features will only be relased under the new `vonage` gem, so make sure to switch as soon as you can.
+
+    To switch now, change your dependency in your `Gemfile` to `vonage` or run `gem install vonage` from the command line.
+    
+    You can find more information on GitHub at https://github.com/Vonage/vonage-ruby-sdk.
+  HEREDOC
   s.metadata = {
     'homepage' => 'https://github.com/Nexmo/nexmo-ruby',
     'source_code_uri' => 'https://github.com/Nexmo/nexmo-ruby',


### PR DESCRIPTION
This adds a post install message and makes a new minor release of the `nexmo` gem to direct people to the new `vonage` namespace gem